### PR TITLE
[XCONTRIB-186] Groovy error on the Run Query tool because the escape tool is called like a velocity variable

### DIFF
--- a/src/main/resources/Admin/RunQuery.xml
+++ b/src/main/resources/Admin/RunQuery.xml
@@ -27,11 +27,13 @@
   def query = request.query;
   if (query==null)
     query = "show processlist";
+  def escapetool = new org.xwiki.velocity.tools.EscapeTool();
+  query = escapetool.xml(query);
 
 println """
 {{html clean=="false"}}
 &lt;form action=""&gt;
- Query: &lt;input type="text" name="query" value="$escapetool.xml($query)" size="80" /&gt;
+ Query: &lt;input type="text" name="query" value="$query" size="80" /&gt;
  &lt;input type="submit" value="Go" /&gt; 
 &lt;/form&gt;
 {{/html}}


### PR DESCRIPTION
Fixed the use of the escapetool utility in groovy
