### PR TITLE
Fix deprecated $velocityCount usage

### DIFF
--- a/src/main/resources/Admin/ExportPageSuggest.xml
+++ b/src/main/resources/Admin/ExportPageSuggest.xml
@@ -29,7 +29,7 @@
 #set($results = $queryResult.toArray())
     &lt;results type="8"&gt;
     #foreach($res in $results)
-      &lt;rs id="$velocityCount" info=""&gt;$res&lt;/rs&gt;
+      &lt;rs id="$foreach.count" info=""&gt;$res&lt;/rs&gt;
     #end
     &lt;/results&gt;
 {{/velocity}}</content>

--- a/src/main/resources/Admin/ExportSpaceSuggest.xml
+++ b/src/main/resources/Admin/ExportSpaceSuggest.xml
@@ -29,7 +29,7 @@
 #set($results = $queryResult.toArray())
     &lt;results type="8"&gt;
     #foreach($res in $results)
-      &lt;rs id="$velocityCount" info=""&gt;$res&lt;/rs&gt;
+      &lt;rs id="$foreach.count" info=""&gt;$res&lt;/rs&gt;
     #end
     &lt;/results&gt;
 {{/velocity}}</content>


### PR DESCRIPTION
Replace deprecate $velocityCount by $foreach.count.

This is a very minimal change to avoid some warning in the logs :wink: 