### PR TITLE
Fix detection of incompatible XWiki version

### DIFF
--- a/src/main/resources/Admin/DB2FS.xml
+++ b/src/main/resources/Admin/DB2FS.xml
@@ -45,7 +45,6 @@
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.doc.DeletedAttachment;
-import org.xwiki.store.legacy.doc.internal.ListAttachmentArchive;
 import com.xpn.xwiki.store.XWikiAttachmentStoreInterface;
 import org.xwiki.store.legacy.store.internal.FilesystemAttachmentStore;
 import com.xpn.xwiki.store.AttachmentVersioningStore;
@@ -352,7 +351,7 @@ private int doIt(int startAt, int seconds, boolean dryRun, boolean verbose, bool
                         // http://jira.xwiki.org/jira/browse/XWIKI-6199
                         attach.getAttachment_archive().getVersions();
                     } catch (NullPointerException e) {
-                        attach.setAttachment_archive(new ListAttachmentArchive([attach]));
+                        attach.setAttachment_archive(new com.xpn.xwiki.internal.doc.ListAttachmentArchive([attach]));
                     }
                     // Setup the runnables to do the save but don't save just yet.
                     fileAttachStore.getAttachmentContentSaveRunnable(attach, false, xc)
@@ -428,7 +427,7 @@ private int doIt(int startAt, int seconds, boolean dryRun, boolean verbose, bool
                 // http://jira.xwiki.org/jira/browse/XWIKI-6199
                 attach.getAttachment_archive().getVersions();
             } catch (NullPointerException e) {
-                attach.setAttachment_archive(new ListAttachmentArchive([attach]));
+                attach.setAttachment_archive(new com.xpn.xwiki.internal.doc.ListAttachmentArchive([attach]));
             }
             if (!dryRun) {
                 fileBin.saveToRecycleBin(attach,


### PR DESCRIPTION
Due to `ListAttachmentArchive` being moved from `org.xwiki.store.legacy.doc.internal` to `com.xpn.xwiki.internal.doc` in XWiki 12.0 the class import fail in any version higher than 12.

Removing the import and using instead a fully qualified class name allow the code in the page that check XWiki for compatibility to successfully being executed instead of failing on the import statement:
```
if (versionEnvironment.compareTo(version910) >= 0)
  print '{{error}}This tool cannot be used in XWiki >= 9.11RC11{{/error}}'
```