### PR TITLE
ADMINTOOL-80 Fix deprecated usage of include macro parameter

### DIFF
--- a/src/main/resources/Admin/WebHome.xml
+++ b/src/main/resources/Admin/WebHome.xml
@@ -38,7 +38,7 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
-  <content>{{include document="Tools" /}}</content>
+  <content>{{include reference="Tools" /}}</content>
   <object>
     <name>Admin.WebHome</name>
     <number>0</number>


### PR DESCRIPTION
According to the [include macro documentation](https://extensions.xwiki.org/xwiki/bin/view/Extension/Include%20Macro), `document` parameter is deprecated since XWiki 3.4M1. This commit replace the usage of `document` by `reference` as recommended in the documentation and in [ADMINTOOL-80](https://jira.xwiki.org/browse/ADMINTOOL-80).