### PR TITLE
Fix MariaDB database detection

### DIFF
--- a/src/main/resources/Admin/SQLToolsGroovy.xml
+++ b/src/main/resources/Admin/SQLToolsGroovy.xml
@@ -224,6 +224,13 @@ class SQLTools{
   }
   
   /**
+   * Get XWiki Database System from HibernateStore
+   */
+   String getXWikiDatabaseSystemFromHibernateStore(xcontext){
+     xcontext.context.getWiki().getHibernateStore().getDatabaseMetaData().getDatabaseProductName()
+   }
+
+  /**
    * Get XWiki Connection
    */
   def getXWikiConnection(xwiki, xcontext){

--- a/src/main/resources/Admin/UsedSpace.xml
+++ b/src/main/resources/Admin/UsedSpace.xml
@@ -59,7 +59,7 @@ __xwikiattrecyclebin__ : Recycle bin of attachments.
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromHibernateStore($xcontext))
   Your database is: **$system**
   #if($system == 'HSQL Database Engine')
     {{warning}}$system is not supported for this action{{/warning}}


### PR DESCRIPTION
So far detection of database product was relying on `HibernateStore` code that report MariaDB as being a MySQL database (to avoid code duplication are both databases are still quite similar).

In order to give a more accurate information about detected database product to the admin this commit duplicate and tune some code of `HibernateStore` and `DatabaseProduct` to correctly report MariaDB database product.