### PR TITLE
Add missing Groovy imports in CheckXWikiConfig and JMXCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Some tools to help the administration of XWiki.
 * Issue Tracker: https://jira.xwiki.org/browse/ADMINTOOL
 * License: LGPL 2.1
 * Development Practices: https://dev.xwiki.org
-* Minimal XWiki version supported: XWiki 4.5.1
+* Minimal XWiki version supported: XWiki 8.4
 * Translations: https://l10n.xwiki.org/projects/xwiki-contrib/admin-tools-application/
 * Sonar Dashboard: N/A
 * Continuous Integration Status: [![Build Status](https://ci.xwiki.org/buildStatus/icon?job=XWiki+Contrib%2Fapplication-admintools%2Fmaster)](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-admintools/job/master/)

--- a/src/main/resources/Admin/CheckXWikiConfig.xml
+++ b/src/main/resources/Admin/CheckXWikiConfig.xml
@@ -46,6 +46,8 @@ import com.xpn.xwiki.util.Util;
 import java.text.DecimalFormat;
 import java.lang.management.ManagementFactory;
 import javax.management.MBeanServer;
+import groovy.jmx.GroovyMBean;
+import groovy.xml.XmlParser;
 
 if( System.getProperty('catalina.base') ) {
   appserverpath = System.getProperty('catalina.base')

--- a/src/main/resources/Admin/JMXCache.xml
+++ b/src/main/resources/Admin/JMXCache.xml
@@ -42,6 +42,7 @@
 import java.lang.management.ManagementFactory;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import groovy.jmx.GroovyMBean;
 
 println """* [[Show cache info&gt;&gt;||queryString=""]]"""
 println """* [[Show cache details&gt;&gt;||queryString="details=1"]]"""


### PR DESCRIPTION
This is breaking with XWiki version >16.0.0 due to change in Groovy 4 (cf https://groovy-lang.org/releasenotes/groovy-4.0.html#Groovy4.0-split-package-renaming) and should have been migrated when using Groovy 3 (https://groovy-lang.org/releasenotes/groovy-3.0.html#Groovy3.0releasenotes-Splitpackages). This is documented in https://www.xwiki.org/xwiki/bin/view/ReleaseNotes/Data/XWiki/16.0.0/#HBreakingchangesinGroovy4.

Fix minimal XWiki version in README file.