### PR TITLE
Add missing fix for database product detection

### DIFF
--- a/src/main/resources/Admin/CheckIndexes.xml
+++ b/src/main/resources/Admin/CheckIndexes.xml
@@ -49,7 +49,7 @@
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
   Your database is: **$system**
   #if($system == "HSQL Database Engine")
     {{warning}}$system is not supported for this action{{/warning}}

--- a/src/main/resources/Admin/QueryOnXWiki.xml
+++ b/src/main/resources/Admin/QueryOnXWiki.xml
@@ -44,7 +44,7 @@
   <content>{{velocity}}
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
   = Query =
   Your database is: **$system**
   $sqlTools.getForm($request, $doc, false, true, $xcontext, $services.csrf.token)

--- a/src/main/resources/Admin/SQLToolsGroovy.xml
+++ b/src/main/resources/Admin/SQLToolsGroovy.xml
@@ -224,9 +224,10 @@ class SQLTools{
   }
   
   /**
-   * Get XWiki Database System from HibernateStore
+   * Get XWiki Database System by extracting product name from database metadata provided by JDBC connection itself
+   * provided by Hibernate
    */
-   String getXWikiDatabaseSystemFromHibernateStore(xcontext){
+   String getXWikiDatabaseSystemFromDatabaseMetadata(xcontext){
      xcontext.context.getWiki().getHibernateStore().getDatabaseMetaData().getDatabaseProductName()
    }
 

--- a/src/main/resources/Admin/ShowLargeHistory.xml
+++ b/src/main/resources/Admin/ShowLargeHistory.xml
@@ -45,7 +45,7 @@
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
   Your database is: **$system**
   #if($system == "HSQL Database Engine")
     {{warning}}$system is not supported for this action{{/warning}}

--- a/src/main/resources/Admin/ShowSpammedPages.xml
+++ b/src/main/resources/Admin/ShowSpammedPages.xml
@@ -48,7 +48,7 @@
 {{info}} Actual spam threshold is set to $threshold {{/info}}
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
   Your database is: **$system**
   #if($system == "HSQL Database Engine")
     {{warning}}$system is not supported for this action{{/warning}}

--- a/src/main/resources/Admin/Tools.xml
+++ b/src/main/resources/Admin/Tools.xml
@@ -80,9 +80,9 @@ The following pages allow advanced administration of an XWiki or XWiki farm:
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
-  #if($system == "MySQL")
-== MySQL Tools ==
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
+  #if($system == "MySQL" || $system == "MariaDB")
+== MySQL/MariaDB Tools ==
 
 * [[MySQL Database Encoding Check&gt;&gt;CheckDBEncoding]]: Tool to check the MySQL database encoding
 * [[MySQL Indexes Check&gt;&gt;CheckIndexes]]: Tool to check MySQL indexes

--- a/src/main/resources/Admin/Tools.xml
+++ b/src/main/resources/Admin/Tools.xml
@@ -80,8 +80,8 @@ The following pages allow advanced administration of an XWiki or XWiki farm:
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
-  #if($system == "MySQL" || $system == "MariaDB")
+  #set($system = $sqlTools.getXWikiDatabaseSystem($xwiki, $xcontext))
+  #if($system == "MySQL")
 == MySQL/MariaDB Tools ==
 
 * [[MySQL Database Encoding Check&gt;&gt;CheckDBEncoding]]: Tool to check the MySQL database encoding

--- a/src/main/resources/Admin/UsedSpace.xml
+++ b/src/main/resources/Admin/UsedSpace.xml
@@ -59,7 +59,7 @@ __xwikiattrecyclebin__ : Recycle bin of attachments.
 
 #if($hasProgramming)
   #set($sqlTools = $xwiki.parseGroovyFromPage('Admin.SQLToolsGroovy'))
-  #set($system = $sqlTools.getXWikiDatabaseSystemFromHibernateStore($xcontext))
+  #set($system = $sqlTools.getXWikiDatabaseSystemFromDatabaseMetadata($xcontext))
   Your database is: **$system**
   #if($system == 'HSQL Database Engine')
     {{warning}}$system is not supported for this action{{/warning}}


### PR DESCRIPTION
Commit 0cb1943013aa6bef62d9a77c601581a2becf48f8 introduce a fix for database product detection that is used in `UsedSpace` tool but forgot to update similar code in various other pages. This commit fix that and also used a better naming for the newly introduce method (`getXWikiDatabaseSystemFromDatabaseMetadata` instead of `getXWikiDatabaseSystemFromHibernateStore`).